### PR TITLE
#6 Некорректная работа с кириллицей в базе данных

### DIFF
--- a/DatabaseProviders/PostgreSQLProvider/PostgreSQLProvider.cpp
+++ b/DatabaseProviders/PostgreSQLProvider/PostgreSQLProvider.cpp
@@ -7,6 +7,8 @@
 #include "PostgreSQLProvider.h"
 #include "PostgreSQLQuery.h"
 
+#include <SDK/Helpers/StringHelper.h>
+
 PostgreSQLProvider::PostgreSQLProvider() :
     _connection(nullptr),
     _formater(new DefaultDatabaseFormatter())
@@ -21,7 +23,7 @@ PostgreSQLProvider::~PostgreSQLProvider()
 void PostgreSQLProvider::open(const AbstractConnectionStringProvider &connectionString)
 {
     auto cstr = connectionString.toString();
-    char cs[cstr.length()];
+    char cs[StringHelper::StringLength(cstr)];
     StringHelper::StringToConstChar(cstr, cs);
     _connection = PQconnectdb(cs);
     if (PQstatus((const PGconn *) _connection) == CONNECTION_BAD)

--- a/SDK/Database/AbstractDatabaseProvider.cpp
+++ b/SDK/Database/AbstractDatabaseProvider.cpp
@@ -23,7 +23,7 @@ AbstractDatabaseProvider::~AbstractDatabaseProvider()
 
 std::shared_ptr<AbstractDatabaseQuery> AbstractDatabaseProvider::exec(const QStringView &sql) const
 {
-    char cs[sql.length()];
+    char cs[StringHelper::StringLength(sql)];
     StringHelper::StringToConstChar(sql, cs);
     return exec(cs);
 }

--- a/SDK/Defines.h
+++ b/SDK/Defines.h
@@ -19,7 +19,7 @@
                                 name& operator= (name const&) = delete; \
                                 name(name const &&) = delete; \
                                 name& operator= (name const &&) = delete; \
-                                public: static name &Instance() { static name inst; return inst; }
+                                public: static name &Instance();
 
 #define STATIC(name)         private: name() = delete; \
                              ~name() = delete; \

--- a/SDK/Helpers/EntityHelper.cpp
+++ b/SDK/Helpers/EntityHelper.cpp
@@ -17,6 +17,12 @@ EntityHelper::EntityHelper()
 
 }
 
+EntityHelper & EntityHelper::Instance()
+{
+    static EntityHelper inst;
+    return inst;
+}
+
 void EntityHelper::Load(const AbstractDatabaseQuery *query, AbstractEntity *entity)
 {
     WritePropertiesPrivate(entity, entity->metaObject(), query);

--- a/SDK/Helpers/StringHelper.cpp
+++ b/SDK/Helpers/StringHelper.cpp
@@ -9,21 +9,27 @@ StringHelper::StringHelper() :
 
 }
 
+StringHelper &StringHelper::Instance()
+{
+    static StringHelper inst;
+    return inst;
+}
+
 void StringHelper::StringToConstChar(const QString &data, char *buffer)
 {
-    auto ba = data.toLatin1();
+    auto ba = data.toUtf8();
     strcpy(buffer, ba.constData());
 }
 
 void StringHelper::StringToConstChar(const QStringView &data, char *buffer)
 {
-    auto ba = data.toLatin1();
+    auto ba = data.toUtf8();
     strcpy(buffer, ba.constData());
 }
 
 i32 StringHelper::StringLength(const QStringView &data)
 {
-    return data.toLatin1().length();
+    return data.toUtf8().length();
 }
 
 void StringHelper::GetRandomString(QString &data, i16 size)


### PR DESCRIPTION
#6 Некорректная работа с кириллицей в базе   данных
- Переработаны синглтоны. Реализация получения инстанса перенесена в исполняемый файл для того, чтобы корректно работали из библиотек
- StringHelper переведен на работу с Unicode
- В PostgreSQLProvider получение длины строк под буффер переведены на StringHelper::StringLength